### PR TITLE
Revert to atomWith* API

### DIFF
--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -1,15 +1,15 @@
 import {
   environmentAtom,
-  atomsWithQuery,
-  atomsWithMutation,
-  atomsWithSubscription,
+  atomWithQuery,
+  atomWithMutation,
+  atomWithSubscription,
 } from '../src/index';
 
 describe('basic spec', () => {
   it('should export functions', () => {
     expect(environmentAtom).toBeDefined();
-    expect(atomsWithQuery).toBeDefined();
-    expect(atomsWithMutation).toBeDefined();
-    expect(atomsWithSubscription).toBeDefined();
+    expect(atomWithQuery).toBeDefined();
+    expect(atomWithMutation).toBeDefined();
+    expect(atomWithSubscription).toBeDefined();
   });
 });

--- a/examples/01_minimal/src/App.js
+++ b/examples/01_minimal/src/App.js
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { Provider, useAtom } from 'jotai';
-import { environmentAtom, atomsWithQuery } from 'jotai-relay';
+import { environmentAtom, atomWithQuery } from 'jotai-relay';
 import { Environment, Network, RecordSource, Store } from 'relay-runtime';
 import graphql from 'babel-plugin-relay/macro';
 
@@ -21,7 +21,7 @@ const myEnvironment = new Environment({
   store: new Store(new RecordSource()),
 });
 
-const [countriesAtom] = atomsWithQuery(
+const countriesAtom = atomWithQuery(
   graphql`
     query AppCountriesQuery {
       countries {

--- a/examples/02_typescript/src/App.tsx
+++ b/examples/02_typescript/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { Provider, useAtom } from 'jotai';
-import { environmentAtom, atomsWithQuery } from 'jotai-relay';
+import { environmentAtom, atomWithQuery } from 'jotai-relay';
 import { Environment, Network, RecordSource, Store } from 'relay-runtime';
 // eslint-disable-next-line
 // @ts-ignore
@@ -25,7 +25,7 @@ const myEnvironment = new Environment({
   store: new Store(new RecordSource()),
 });
 
-const [countriesAtom] = atomsWithQuery<AppCountriesQuery>(
+const countriesAtom = atomWithQuery<AppCountriesQuery>(
   graphql`
     query AppCountriesQuery {
       countries {

--- a/examples/03_errorhandling/src/App.tsx
+++ b/examples/03_errorhandling/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { Provider, atom, useAtom, useSetAtom } from 'jotai';
-import { environmentAtom, atomsWithQuery } from 'jotai-relay';
+import { environmentAtom, atomWithQuery } from 'jotai-relay';
 import { Environment, Network, RecordSource, Store } from 'relay-runtime';
 // eslint-disable-next-line
 // @ts-ignore
@@ -31,7 +31,7 @@ const myEnvironment = new Environment({
 
 const filterAtom = atom<CountryFilterInput | null>({});
 
-const [countriesAtom] = atomsWithQuery<AppCountriesQuery>(
+const countriesAtom = atomWithQuery<AppCountriesQuery>(
   graphql`
     query AppCountriesQuery($filter: CountryFilterInput) {
       countries(filter: $filter) {

--- a/src/atomWithMutation.ts
+++ b/src/atomWithMutation.ts
@@ -8,12 +8,9 @@ import { atom } from 'jotai';
 import type { Getter, WritableAtom } from 'jotai';
 import { environmentAtom } from './environmentAtom';
 
-export function atomsWithMutation<T extends MutationParameters>(
+export function atomWithMutation<T extends MutationParameters>(
   getEnvironment: (get: Getter) => Environment = (get) => get(environmentAtom),
-): readonly [
-  dataAtom: WritableAtom<undefined, MutationConfig<T>>,
-  statusAtom: WritableAtom<undefined, MutationConfig<T>>,
-] {
+): WritableAtom<undefined, MutationConfig<T>> {
   const mutationAtom = atom(
     // Don't we have any valid value for this atom??
     undefined,
@@ -23,6 +20,5 @@ export function atomsWithMutation<T extends MutationParameters>(
       commitMutation(environment, config);
     },
   );
-  // A little unfortunate to return the same atom
-  return [mutationAtom, mutationAtom] as const;
+  return mutationAtom;
 }

--- a/src/atomWithQuery.ts
+++ b/src/atomWithQuery.ts
@@ -6,7 +6,7 @@ import type {
 } from 'relay-runtime';
 import type { Getter, WritableAtom } from 'jotai';
 import { environmentAtom } from './environmentAtom';
-import { createAtoms } from './common';
+import { createAtom } from './common';
 
 type Config = Parameters<typeof fetchQuery>[3];
 
@@ -14,16 +14,13 @@ type Action = {
   type: 'refetch';
 };
 
-export function atomsWithQuery<T extends OperationType>(
+export function atomWithQuery<T extends OperationType>(
   taggedNode: GraphQLTaggedNode,
   getVariables: (get: Getter) => T['variables'],
   getConfig?: (get: Getter) => Config,
   getEnvironment: (get: Getter) => Environment = (get) => get(environmentAtom),
-): readonly [
-  dataAtom: WritableAtom<T['response'], Action>,
-  statusAtom: WritableAtom<T['response'] | undefined, Action>,
-] {
-  return createAtoms(
+): WritableAtom<T['response'], Action> {
+  return createAtom(
     (get) => [taggedNode, getVariables(get), getConfig?.(get)] as const,
     getEnvironment,
     (environment, args) => fetchQuery(environment, ...args),

--- a/src/atomWithSubscription.ts
+++ b/src/atomWithSubscription.ts
@@ -8,7 +8,7 @@ import type {
 } from 'relay-runtime';
 import type { Getter, WritableAtom } from 'jotai';
 import { environmentAtom } from './environmentAtom';
-import { createAtoms } from './common';
+import { createAtom } from './common';
 
 type Configs = Parameters<typeof requestSubscription>[1]['configs'];
 
@@ -16,17 +16,14 @@ type Action = {
   type: 'refetch';
 };
 
-export function atomsWithSubscription<T extends OperationType>(
+export function atomWithSubscription<T extends OperationType>(
   taggedNode: GraphQLTaggedNode,
   getVariables: (get: Getter) => T['variables'],
   getConfigs?: (get: Getter) => Configs,
   updater?: SelectorStoreUpdater<T['response']>,
   getEnvironment: (get: Getter) => Environment = (get) => get(environmentAtom),
-): readonly [
-  dataAtom: WritableAtom<T['response'], Action>,
-  statusAtom: WritableAtom<T['response'] | undefined, Action>,
-] {
-  return createAtoms(
+): WritableAtom<T['response'], Action> {
+  return createAtom(
     (get) => ({
       configs: getConfigs?.(get),
       subscription: taggedNode,

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,7 +3,7 @@ import { atom } from 'jotai';
 import type { Getter } from 'jotai';
 import { atomWithObservable } from 'jotai/utils';
 
-export const createAtoms = <
+export const createAtom = <
   Args,
   Result,
   Action,
@@ -28,28 +28,6 @@ export const createAtoms = <
     return observable;
   });
 
-  const baseStatusAtom = atom((get) => {
-    const observable = get(observableAtom);
-    const resultAtom = atomWithObservable(() => observable, {
-      initialValue: undefined,
-    });
-    return resultAtom;
-  });
-
-  const statusAtom = atom(
-    (get) => {
-      const resultAtom = get(baseStatusAtom);
-      return get(resultAtom);
-    },
-    (get, set, action: Action) => {
-      const environment = getEnvironment(get);
-      const refresh = () => {
-        set(refreshAtom, (c) => c + 1);
-      };
-      return handleAction(action, environment, refresh);
-    },
-  );
-
   const baseDataAtom = atom((get) => {
     const observable = get(observableAtom);
     const resultAtom = atomWithObservable(() => observable);
@@ -62,8 +40,14 @@ export const createAtoms = <
       const result = get(resultAtom);
       return result;
     },
-    (_get, set, action: Action) => set(statusAtom, action),
+    (get, set, action: Action) => {
+      const environment = getEnvironment(get);
+      const refresh = () => {
+        set(refreshAtom, (c) => c + 1);
+      };
+      return handleAction(action, environment, refresh);
+    },
   );
 
-  return [dataAtom, statusAtom] as const;
+  return dataAtom;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { environmentAtom } from './environmentAtom';
-export { atomsWithQuery } from './atomsWithQuery';
-export { atomsWithMutation } from './atomsWithMutation';
-export { atomsWithSubscription } from './atomsWithSubscription';
+export { atomWithQuery } from './atomWithQuery';
+export { atomWithMutation } from './atomWithMutation';
+export { atomWithSubscription } from './atomWithSubscription';


### PR DESCRIPTION
In #1, we followed `atomsWith*` style, but it feels weird. If Relay API doesn't return other than data, let's stick with `atomWith*` API.